### PR TITLE
PntML では X軸が東西方向，Y軸が南北方向という説明を追加．

### DIFF
--- a/docs/pcm/pcm-api.yml
+++ b/docs/pcm/pcm-api.yml
@@ -98,9 +98,13 @@ paths:
   /pcms/{title}:
     post:
       summary: Uploads a set of point cloud files and Stores them into the PCM
-      description: >-
+      description: |
         A user uploads a set of point cloud files into a specific PCM.
         This method is mandatory to be implemented. Pass the transform information and GPSTime initial value as a JSON file to the config parameter. The supported file formats are "las", "csv", "pcd" and "ply".
+
+        Note that, in PntML, the east-west direction is defined as the x-axis and the north-south direction as the y-axis.
+        Therefore, as the order of latlon, (longitude, latitude) is used instead of (latitude, longitude) in PntML.
+        Coordinate systems such as Japan Plane Rectangular CS IX also define the north-south direction as the X-axis and the east-west direction as the Y-axis, but the direction of axis is different from these coordinate systems.
       operationId: uploadPointClouds
       tags:
         - PointClouds
@@ -366,9 +370,13 @@ paths:
   /processes/search:
     post:
       summary: Creates a new search process with conditions and executes it ASYNCHRONOUSLY
-      description: >-
+      description: |
         A user can search point cloud data with more complex conditions asynchronously.
         This method is mandatory to be implemented.
+
+        Note that, in PntML, the east-west direction is defined as the x-axis and the north-south direction as the y-axis.
+        Therefore, as the order of latlon, (longitude, latitude) is used instead of (latitude, longitude) in PntML.
+        Coordinate systems such as Japan Plane Rectangular CS IX also define the north-south direction as the X-axis and the east-west direction as the Y-axis, but the direction of axis is different from these coordinate systems.
       operationId: searchProcess
       tags:
         - Processes
@@ -421,16 +429,22 @@ paths:
   /processes/voxelize:
     post:
       summary: Creates a new process of voxelization with conditions and executes it ASYNCHRONOUSLY
-      description: >-
+      description: |
         A user can calculate voxelized point cloud data with filtering conditions asynchonously.
+
         A parameter allows you to select whether to output color information. 
         The attributes of the result data with color information are "coordinates (longitude, latitude, height of WGS84 or x, y, z)", "intensity", "red", "green", and "blue". 
         "Intensity", "Red", "Green", and "Blue" of the result data are the average value of the point cloud in the voxel.
         The only attribute of the result data without color information is coordinates.
+
         (EPSG:32601-32660,32701-32760)
         the EPSG code is determined from the coordinate value of the point cloud to be searched.
         If the point cloud to be searched spans multiple EPSG codes, the processing will be stopped.
         This method is mandatory to be implemented.
+
+        Note that, in PntML, the east-west direction is defined as the x-axis and the north-south direction as the y-axis.
+        Therefore, as the order of latlon, (longitude, latitude) is used instead of (latitude, longitude) in PntML.
+        Coordinate systems such as Japan Plane Rectangular CS IX also define the north-south direction as the X-axis and the east-west direction as the Y-axis, but the direction of axis is different from these coordinate systems.
       operationId: voxelProcess
       tags:
         - Processes

--- a/docs/pcm/schemas/Transform.yml
+++ b/docs/pcm/schemas/Transform.yml
@@ -12,7 +12,11 @@ properties:
     description: |
       The origin coordinates of the posted point cloud based on WGS84.
 
-      The default value is [0,0,0].
+      The default is nothing.
+      If `origin` is not given, even `euler` and/or `scale` is given, 
+      then the coordinate transformation of the posted pointcloud does NOT performed 
+      and the pointcloud is stored as it is as the coordinates based on the specified CRS in `transformCRS`.
+
       The unit of each value is Decimal Degree (DD) of WGS84, but not Degrees Minutes Seconds (DMS).
 
       The format is [longitude, latitude] or [longitude, latitude, altitude].    
@@ -21,7 +25,7 @@ properties:
       Before transforming the coordinates of each point, the origin point is transformed  from WGS84 to the coordinate system specified by `transformCRS`.
 
       For example: 
-      If the following JSON is given, WGS84-based origin (139.7780996958115, 35.61846131695731, 0) is transformed to (-5003.445813743943, -42328.165818379086, 0) in JGD2011 / Japan Plane Rectangular CS IX (EPSG:6677).
+      If the following JSON is given, WGS84-based origin (139.7780996958115, 35.61846131695731, 0) is transformed to (-5003.445813743943, -42328.165818379086, 0) in EPSG:6677(JGD2011 / Japan Plane Rectangular CS IX).
       This transformed origin coordinates are used as the origin of the posted point cloud.
       ```JSON
       {


### PR DESCRIPTION
Closes #50 

PntML では X軸が東西方向，Y軸が南北方向．
そのため緯度経度の順ではなく，（経度，緯度）となる

一般的にはあらゆる座標系では，X軸が南北方向でY軸方向が東西方向とのことなので注意が必要

